### PR TITLE
Command to verify the mnemonic and passphrase

### DIFF
--- a/haskoin-wallet.cabal
+++ b/haskoin-wallet.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3a09ee5a54cbb8291ce9925e53adb95e29db8f16435843ca8d381bc144e4a675
+-- hash: 9428b61cc16c2222adae2f1931d2eb6ac71299ed2352c243d9c7f9e298c51bef
 
 name:           haskoin-wallet
-version:        0.7.1
+version:        0.7.2
 synopsis:       Lightweight command-line wallet for Bitcoin and Bitcoin Cash
 description:    haskoin-wallet (hw) is a lightweight Bitcoin wallet using BIP39 mnemonics and
                 BIP44 account structure. It requires a full blockchain index such as
@@ -100,7 +100,7 @@ executable hw
     , haskeline >=0.7.5.0
     , haskoin-core >=1.0.0
     , haskoin-store-data >=1.0.0
-    , haskoin-wallet ==0.7.1
+    , haskoin-wallet ==0.7.2
     , http-types >=0.12.3
     , lens >=4.18.1
     , lens-aeson >=1.1
@@ -151,7 +151,7 @@ test-suite spec
     , haskeline >=0.7.5.0
     , haskoin-core >=1.0.0
     , haskoin-store-data >=1.0.0
-    , haskoin-wallet ==0.7.1
+    , haskoin-wallet ==0.7.2
     , hspec >=2.7.1
     , http-types >=0.12.3
     , lens >=4.18.1

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: haskoin-wallet
-version: &version 0.7.1
+version: &version 0.7.2
 synopsis: Lightweight command-line wallet for Bitcoin and Bitcoin Cash
 description: !
   haskoin-wallet (hw) is a lightweight Bitcoin wallet using BIP39 mnemonics and

--- a/src/Network/Haskoin/Wallet/AccountStore.hs
+++ b/src/Network/Haskoin/Wallet/AccountStore.hs
@@ -224,7 +224,7 @@ getAccountStore keyM = do
     Just key ->
       case key `Map.lookup` accMap of
         Just val -> return (key, val)
-        _ -> throwError $ "The account " <> cs key <> "does not exist"
+        _ -> throwError $ "The account " <> cs key <> " does not exist"
 
 getAccountStoreByDeriv ::
   (MonadState AccountMap m, MonadError String m) =>

--- a/src/Network/Haskoin/Wallet/Commands.hs
+++ b/src/Network/Haskoin/Wallet/Commands.hs
@@ -663,6 +663,8 @@ balance ctx accM =
     withAccountStore ctx accM $ \storeName -> do
       net <- gets accountStoreNetwork
       addrMap <- gets (storeAddressMap ctx)
+      when (Map.null addrMap) $
+        throwError "The account has no addresses yet"
       checkHealth ctx net
       let req = GetAddrsBalance (Map.keys addrMap)
       Store.SerialList bals <-

--- a/src/Network/Haskoin/Wallet/Commands.hs
+++ b/src/Network/Haskoin/Wallet/Commands.hs
@@ -37,8 +37,7 @@ import Haskoin.Crypto
     XPrvKey,
     deriveXPubKey,
     fromMnemonic,
-    mnemonicToSeed,
-    pathToList,
+    pathToList, HardPath,
   )
 import Haskoin.Network (Network (name), netByName)
 import qualified Haskoin.Store.Data as Store
@@ -64,7 +63,7 @@ import Network.Haskoin.Wallet.AccountStore
       ( accountStoreExternal,
         accountStoreInternal,
         accountStoreNetwork,
-        accountStoreXPubKey
+        accountStoreXPubKey, accountStoreDeriv
       ),
     accountStoreAccount,
     addrsDerivPage,
@@ -140,7 +139,7 @@ import Network.Haskoin.Wallet.Util
 import Numeric.Natural (Natural)
 import qualified System.Console.Haskeline as Haskeline
 import qualified System.Directory as D
-import System.IO (putStrLn)
+import Data.Bits (clearBit)
 
 -- | Version of Haskoin Wallet package.
 versionString :: (IsString a) => a
@@ -185,6 +184,12 @@ data Response
       { responseAccountName :: !Text,
         responseAccount :: !AccountStore,
         responsePubKeyFile :: !Text
+      }
+  | ResponseTestAcc
+      { responseAccountName :: !Text,
+        responseAccount :: !AccountStore,
+        responseResult :: !Bool,
+        responseText :: !Text
       }
   | ResponseImportAcc
       { responseAccountName :: !Text,
@@ -285,6 +290,14 @@ instance MarshalJSON Ctx Response where
             "accountname" .= n,
             "account" .= marshalValue ctx a,
             "pubkeyfile" .= f
+          ]
+      ResponseTestAcc n a b t ->
+        object
+          [ "type" .= Json.String "testacc",
+            "accountname" .= n,
+            "account" .= marshalValue ctx a,
+            "result" .= b,
+            "text" .= t
           ]
       ResponseImportAcc n a ->
         object
@@ -412,6 +425,12 @@ instance MarshalJSON Ctx Response where
           a <- unmarshalValue ctx =<< o .: "account"
           f <- o .: "pubkeyfile"
           return $ ResponseCreateAcc n a f
+        "testacc" -> do
+          n <- o .: "accountname"
+          a <- unmarshalValue ctx =<< o .: "account"
+          b <- o .: "result"
+          t <- o .: "text"
+          return $ ResponseTestAcc n a b t
         "importacc" -> do
           n <- o .: "accountname"
           a <- unmarshalValue ctx =<< o .: "account"
@@ -548,6 +567,7 @@ commandResponse ctx =
   \case
     CommandMnemonic e d s -> mnemonic e d s
     CommandCreateAcc t n dM s -> createAcc ctx t n dM s
+    CommandTestAcc accM s -> testAcc ctx accM s
     CommandImportAcc f -> importAcc ctx f
     CommandRenameAcc old new -> renameAcc ctx old new
     CommandAccounts -> accounts ctx
@@ -589,6 +609,31 @@ createAcc ctx name net derivM splitIn =
             responseAccount = store,
             responsePubKeyFile = cs path
           }
+
+testAcc :: Ctx -> Maybe Text -> Natural -> IO Response
+testAcc ctx accM splitIn =
+  catchResponseError $
+  withAccountStore ctx accM $ \storeName -> do
+    store <- get
+    net <- gets accountStoreNetwork
+    d <- gets accountStoreDeriv
+    pubKey <- gets accountStoreXPubKey
+    prvKey <- lift $ askSigningKey ctx net (pathToAccount d) splitIn
+    return $
+      if deriveXPubKey ctx prvKey == pubKey
+        then ResponseTestAcc
+               storeName
+               store
+               True
+               "The mnemonic and passphrase matched the account"
+        else ResponseTestAcc
+               storeName
+               store
+               False
+               "The mnemonic and passphrase did not match the account"
+
+pathToAccount :: HardPath -> Natural
+pathToAccount = fromIntegral . (`clearBit` 31) . last . pathToList
 
 importAcc :: Ctx -> FilePath -> IO Response
 importAcc ctx fp =

--- a/src/Network/Haskoin/Wallet/Entropy.hs
+++ b/src/Network/Haskoin/Wallet/Entropy.hs
@@ -188,6 +188,7 @@ genMnemonic ::
   Natural ->
   ExceptT String IO (Text, Mnemonic, [Mnemonic])
 genMnemonic reqEnt reqDice splitIn
+  | splitIn == 0 = throwError "Invalid split option"
   | reqEnt `elem` [16, 20 .. 32] = do
       (origEnt, sysEnt) <- liftIO $ systemEntropy reqEnt
       ent <-

--- a/src/Network/Haskoin/Wallet/Parser.hs
+++ b/src/Network/Haskoin/Wallet/Parser.hs
@@ -80,6 +80,10 @@ data Command
         commandDerivation :: !(Maybe Natural),
         commandSplitIn :: !Natural
       }
+  | CommandTestAcc
+      { commandMaybeAcc :: !(Maybe Data.Text.Text),
+        commandSplitIn :: !Natural
+      }
   | CommandImportAcc
       { commandFilePath :: !FilePath
       }
@@ -163,6 +167,7 @@ commandParser ctx =
           [ commandGroup "Mnemonic and account management",
             command "mnemonic" mnemonicParser,
             command "createacc" createAccParser,
+            command "testacc" (testAccParser ctx),
             command "importacc" importAccParser,
             command "renameacc" (renameAccParser ctx),
             command "accounts" accountsParser,
@@ -242,6 +247,17 @@ createAccParser =
           \ sign transactions. The public key file for the account will be\
           \ stored in ~/.hw/pubkeys which can be imported on an online\
           \ computer."
+      ]
+
+testAccParser :: Ctx -> ParserInfo Command
+testAccParser ctx =
+  info (CommandTestAcc <$> accountOption ctx <*> splitInOption) $
+    mconcat
+      [ progDescDoc $ offline "Test your mnemonic and passphrase",
+        footer
+          "You should test regularly the mnemonic and passphrase of your account.\
+          \ This command will derive the public key associated with the account\
+          \ and make sure that it matches the account on file."
       ]
 
 importAccParser :: ParserInfo Command

--- a/src/Network/Haskoin/Wallet/Parser.hs
+++ b/src/Network/Haskoin/Wallet/Parser.hs
@@ -491,7 +491,7 @@ diceOption =
 
 splitInOption :: Parser Natural
 splitInOption =
-  option (maybeReader $ readNatural . cs) $
+  option (eitherReader $ f . cs) $
     mconcat
       [ short 's',
         long "split",
@@ -501,6 +501,14 @@ splitInOption =
         metavar "INT",
         value 1
       ]
+  where
+    f s =
+      case readNatural s of
+        Just n ->
+          if n >= 2 && n <= 12
+            then Right n
+            else Left "Split value has to be in the range [2-12]"
+        Nothing -> Left "Could not parse the split option"
 
 entropyOption :: Parser Natural
 entropyOption =

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,7 @@ extra-deps:
   - git: https://github.com/haskoin/haskoin-core.git
     commit: 520b0b241f7e108771b0b0fd274a7c329f65ce1c
   - git: https://github.com/haskoin/haskoin-store.git
-    commit: ec282a95bdb4f4900da540c5d777c328e378ce36
+    commit: bc8b99428fedbe88b3dcf80dd4ae298b682112fb
     subdirs:
     - data
+  - scotty-0.20@sha256:f9b3f21773f813e92e41a6b5eee1fbefbbe0c695ac5259413500270ec0847151,5292

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -16,18 +16,25 @@ packages:
     commit: 520b0b241f7e108771b0b0fd274a7c329f65ce1c
     git: https://github.com/haskoin/haskoin-core.git
 - completed:
-    commit: ec282a95bdb4f4900da540c5d777c328e378ce36
+    commit: bc8b99428fedbe88b3dcf80dd4ae298b682112fb
     git: https://github.com/haskoin/haskoin-store.git
     name: haskoin-store-data
     pantry-tree:
-      sha256: 358864bbacdb6db4a777d74042dce0e2157b0a719b96c56fc5218fda10361573
+      sha256: fa2a2cdca5a3d0531d81269eee4fa1e8e318e86e519a64673da9915579c37f59
       size: 624
     subdir: data
-    version: 1.1.0
+    version: 1.2.0
   original:
-    commit: ec282a95bdb4f4900da540c5d777c328e378ce36
+    commit: bc8b99428fedbe88b3dcf80dd4ae298b682112fb
     git: https://github.com/haskoin/haskoin-store.git
     subdir: data
+- completed:
+    hackage: scotty-0.20@sha256:f9b3f21773f813e92e41a6b5eee1fbefbbe0c695ac5259413500270ec0847151,5292
+    pantry-tree:
+      sha256: 4666d49e36443b9ec6d16257fe5ed971e3fdf7111b5996a316372729523038c9
+      size: 1945
+  original:
+    hackage: scotty-0.20@sha256:f9b3f21773f813e92e41a6b5eee1fbefbbe0c695ac5259413500270ec0847151,5292
 snapshots:
 - completed:
     sha256: d4a54df12888fc5d1ef2d4ff987225fa7bedb2cff74385b33fbec4a384ebd619


### PR DESCRIPTION
* Add a new testacc command to verify the mnemonic and passphrase
* Limit the --split option to the range [2,12]
* Easier mnemonic and passphrase input