### PR TITLE
Sweep transactions now sweep directly from private keys

### DIFF
--- a/haskoin-wallet.cabal
+++ b/haskoin-wallet.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 76af62b27fc56cea5da6e5657f63f55b7f1ba2458df076077aa939af1f2d6aae
+-- hash: 60ebec3c20572cfb0344f54196b16af1b9bb2ae7e956d1196b1841b0ea792acd
 
 name:           haskoin-wallet
-version:        0.8.2
+version:        0.8.3
 synopsis:       Lightweight command-line wallet for Bitcoin and Bitcoin Cash
 description:    haskoin-wallet (hw) is a lightweight Bitcoin wallet using BIP39 mnemonics and
                 BIP44 account structure. It requires a full blockchain index such as
@@ -112,7 +112,7 @@ executable hw
     , haskeline >=0.7.5.0
     , haskoin-core >=1.0.4
     , haskoin-store-data >=1.2.2
-    , haskoin-wallet ==0.8.2
+    , haskoin-wallet ==0.8.3
     , http-types >=0.12.3
     , lens >=4.18.1
     , lens-aeson >=1.1
@@ -170,7 +170,7 @@ test-suite spec
     , haskeline >=0.7.5.0
     , haskoin-core >=1.0.4
     , haskoin-store-data >=1.2.2
-    , haskoin-wallet ==0.8.2
+    , haskoin-wallet ==0.8.3
     , hspec >=2.7.1
     , http-types >=0.12.3
     , lens >=4.18.1

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: haskoin-wallet
-version: &version 0.8.2
+version: &version 0.8.3
 synopsis: Lightweight command-line wallet for Bitcoin and Bitcoin Cash
 description: !
   haskoin-wallet (hw) is a lightweight Bitcoin wallet using BIP39 mnemonics and

--- a/src/Haskoin/Wallet/FileIO.hs
+++ b/src/Haskoin/Wallet/FileIO.hs
@@ -12,7 +12,7 @@ import Control.Monad.Reader (MonadIO (..))
 import Data.Aeson
 import Data.Aeson.Types (parseEither)
 import qualified Data.ByteString.Char8 as C8
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (mapMaybe)
 import qualified Data.Serialize as S
 import Data.String.Conversions (cs)
 import Data.Text (Text)
@@ -109,12 +109,6 @@ readFileWords :: FilePath -> IO [[Text]]
 readFileWords fp = do
   strContents <- IO.readFile fp
   return $ removeComments $ Text.words <$> Text.lines (cs strContents)
-
-parseAddrsFile :: Network -> [[Text]] -> [Address]
-parseAddrsFile net =
-  withParser $ \w -> eitherToMaybe $ textToAddrE net $ strip "addr=" w
-  where
-    strip p w = fromMaybe w $ Text.stripPrefix p w
 
 parseSecKeysFile :: Network -> [[Text]] -> [SecKey]
 parseSecKeysFile net =

--- a/src/Haskoin/Wallet/Parser.hs
+++ b/src/Haskoin/Wallet/Parser.hs
@@ -113,8 +113,7 @@ data Command
   | CommandVersion
   | CommandPrepareSweep
       { commandMaybeAcc :: !(Maybe Text),
-        commandSweepFrom :: ![Text],
-        commandSweepFileMaybe :: !(Maybe FilePath),
+        commandSecKeyPath :: !FilePath,
         commandSweepTo :: ![Text],
         commandOutputFileMaybe :: !(Maybe FilePath),
         commandFeeByte :: !Natural,
@@ -879,8 +878,7 @@ prepareSweepParser = do
   let cmd =
         CommandPrepareSweep
           <$> accountOption
-          <*> many sweepFromOption -- many: not optional
-          <*> addressFileOption
+          <*> prvKeyFileOption
           <*> some sweepToOption -- some: optional
           <*> outputFileMaybeOption
           <*> feeOption
@@ -889,13 +887,11 @@ prepareSweepParser = do
     progDesc "Prepare a transaction to sweep funds"
       <> footer
         [r|
-`preparesweep` will prepare a transaction that sweeps the funds available in the
-given --sweepfrom addresses and sends them to the --sweepto addresses. The
-typical use case for this command is to migrate an old wallet to a new mnemonic.
-The addresses can also be parsed from a --addrfile. The best way to pass
-multiple addresses on the command line is with the shorthand -w ADDR1 -w ADDR2
-for --sweepfrom addresses and -t ADDR1 -t ADDR2 for --sweepto addresses. You
-can generate addresses to sweep to with the `receive` command.
+`preparesweep` will prepare a transaction that sweeps the funds of the given
+private keys. The private keys are passed in a file and can be in WIF or minikey
+format. The typical use case for this command is to migrate an old wallet to a
+new mnemonic. You can send the funds to 1 or multiple addresses. You can use the
+shorthand format -t ADDR1 -t ADDR2 to specify the --sweepto addresses.
 |]
 
 sweepFromOption :: Parser Text


### PR DESCRIPTION
* Sweep transactions no longer need addresses. They can sweep the private keys directly.
* Sweep transaction output amounts are no longer randomized. 
* Improve the output of the command-line pretty printer